### PR TITLE
Clear queue before initiating a new batch of product scans

### DIFF
--- a/src/Controllers/Cron.php
+++ b/src/Controllers/Cron.php
@@ -8,6 +8,7 @@ use Wooping\ShopHealth\Queue\BatchScanProducts;
 use Wooping\ShopHealth\Queue\ScanProduct;
 use Wooping\ShopHealth\Queue\ScanSetting;
 use Wooping\ShopHealth\Validators\SettingContainer;
+use Wooping\ShopHealth\Models\Database\Options;
 use WP_REST_Response;
 
 /**
@@ -35,6 +36,13 @@ class Cron extends Controller {
 	 * Schedule a scan for all available products
 	 */
 	public function schedule_all_product_scans(): void {
+
+		// add timestamp here, so our progress bar can query on a certain timestamp.
+		( new Options() )->set_queue_timestamp();
+
+		// Remove any of the old product scans in the old queue
+		\as_unschedule_all_actions( 'woop_batch_scan_products' );
+		\as_unschedule_all_actions( 'woop_scan_product' );
 
 		// query all products.
 		$product_amount = Scans::get_total_product_amount();

--- a/src/Models/Database/Options.php
+++ b/src/Models/Database/Options.php
@@ -20,6 +20,15 @@ class Options {
 		return $stats;
 	}
 
+
+	/**
+	 * Save a timestamp for when the queue was last updated with issues
+	 */
+	public function set_queue_timestamp(): void {
+		
+		\update_option( 'wooping_shop_health_scan_last_triggered', time() );
+	}
+
 	/**
 	 * Clean up Wooping records in the options table
 	 */

--- a/src/Queue/BatchScanProducts.php
+++ b/src/Queue/BatchScanProducts.php
@@ -4,6 +4,7 @@ namespace Wooping\ShopHealth\Queue;
 
 use WC_Product_Query;
 use Wooping\ShopHealth\Contracts\Queueable;
+use Wooping\ShopHealth\Models\Database\Options;
 
 /**
  * Class BatchScanProducts
@@ -43,6 +44,9 @@ class BatchScanProducts extends Queueable {
 	 * @return void
 	 */
 	public function run( int $page, int $limit ): void {
+
+		// add timestamp here, so our progress bar can query on a certain timestamp.
+		( new Options() )->set_queue_timestamp();
 
 		// get all products in this batch.
 		$products = ( new WC_Product_Query(

--- a/src/Queue/BatchScanProducts.php
+++ b/src/Queue/BatchScanProducts.php
@@ -4,7 +4,6 @@ namespace Wooping\ShopHealth\Queue;
 
 use WC_Product_Query;
 use Wooping\ShopHealth\Contracts\Queueable;
-use Wooping\ShopHealth\Models\Database\Options;
 
 /**
  * Class BatchScanProducts
@@ -44,9 +43,6 @@ class BatchScanProducts extends Queueable {
 	 * @return void
 	 */
 	public function run( int $page, int $limit ): void {
-
-		// add timestamp here, so our progress bar can query on a certain timestamp.
-		( new Options() )->set_queue_timestamp();
 
 		// get all products in this batch.
 		$products = ( new WC_Product_Query(

--- a/src/WooCommerce/Admin/Products.php
+++ b/src/WooCommerce/Admin/Products.php
@@ -6,6 +6,7 @@ use WC_Product;
 use Wooping\ShopHealth\Contracts\Interfaces\Hookable;
 use Wooping\ShopHealth\Models\ScannedObject;
 use Wooping\ShopHealth\Models\Schema\AddScannedObjectsTable;
+use Wooping\ShopHealth\Models\Database\Options;
 use Wooping\ShopHealth\Queue\ScanProduct;
 use WP_Post;
 
@@ -165,6 +166,9 @@ class Products implements Hookable {
 		if ( \in_array( $product->get_status(), [ 'trash', 'auto-draft' ], true ) ) {
 			return;
 		}
+		
+		// add timestamp here, so our progress bar can query on a certain timestamp.
+		( new Options() )->set_queue_timestamp();
 
 		( new ScanProduct() )->scan( $product_id );
 	}


### PR DESCRIPTION
Whenever a bunch of batches op product scans get created, a negative number becomese prominent in the progress bar in the dashboard (see #1), this is because how queued jobs get queried (see #15). At the moment, it seems enough to clear any and all jobs that where associated with a batch scan, and redo the process, but I've also added a last_scan_date in the options table (as per #19 ). This would technically allow us to query the queue-items better, but I don't see a need for that now. 

- Fixes #15 
- Fixes #1 