### PR TITLE
Run update events

### DIFF
--- a/src/WordPress/Updates.php
+++ b/src/WordPress/Updates.php
@@ -101,7 +101,7 @@ class Updates implements Hookable {
 		// Check if we're updating plugins.
 		if ( $this->verify_update_is_ours( $options ) ) {
 			// Schedule the calculation.
-			\as_enqueue_async_action( 'woop_calculate_max_scores', [], '', true );
+			\as_enqueue_async_action( 'woop_calculate_max_scores', [], '', true, 1000 );
 			return;
 		}
 	}

--- a/src/WordPress/Updates.php
+++ b/src/WordPress/Updates.php
@@ -109,7 +109,7 @@ class Updates implements Hookable {
 	/**
 	 * Check if an update being run belongs to us
 	 */
-	public function verify_update_is_ours(): bool {
+	public function verify_update_is_ours( array $options ): bool {
 		if ( $options['action'] === 'update' && $options['type'] === 'plugin' ) {
 			// loop through the plugins that we're updating.
 			foreach ( $options['plugins'] as $plugin ) {


### PR DESCRIPTION
Our update events we're firing. Probably because the `verify_this_update_is_ours` function wasn't getting the correct variable sent along. 

This PR fixes that. Tested it and the update event shows up in the wooping.io log. Additionally, the `calculate_max_scores` queueable was neatly scheduled and ran a couple of seconds after update. I've added a lower priority to this job to prevent it from causing an issue if it updates right away.

- Fixes #25 