### PR TITLE
Fail gracefully if update api cant be reached

### DIFF
--- a/src/WordPress/Updates.php
+++ b/src/WordPress/Updates.php
@@ -16,7 +16,7 @@ class Updates implements Hookable {
 	/**
 	 * The url constants with which we communicate to the world outside.
 	 */
-	protected const UPDATE_URL   = 'https://staging.wooping.io/wp-json/wooping/v1/updates/wooping-shop-health';
+	protected const UPDATE_URL   = 'https://updates.wooping.io/wooping-shop-health';
 	protected const FEEDBACK_URL = 'https://wooping.io/wp-json/wooping/v1/';
 
 	/**

--- a/src/WordPress/Updates.php
+++ b/src/WordPress/Updates.php
@@ -2,6 +2,7 @@
 
 namespace Wooping\ShopHealth\WordPress;
 
+use Throwable;
 use Wooping\ShopHealth\Contracts\Interfaces\Hookable;
 use WP_Upgrader;
 use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
@@ -36,7 +37,7 @@ class Updates implements Hookable {
 					'shop-health'
 				);
 
-			}catch ( Throwable $error ) {
+			} catch ( Throwable $error ) {
 				// Do nothing. Just no new updates found.
 			}
 		}

--- a/src/WordPress/Updates.php
+++ b/src/WordPress/Updates.php
@@ -16,7 +16,7 @@ class Updates implements Hookable {
 	/**
 	 * The url constants with which we communicate to the world outside.
 	 */
-	protected const UPDATE_URL   = 'https://updates.wooping.io/wooping-shop-health';
+	protected const UPDATE_URL   = 'https://staging.wooping.io/wp-json/wooping/v1/updates/wooping-shop-health';
 	protected const FEEDBACK_URL = 'https://wooping.io/wp-json/wooping/v1/';
 
 	/**
@@ -29,11 +29,16 @@ class Updates implements Hookable {
 		// Register git updater, if it exists.
 		if ( \class_exists( 'YahnisElsts\PluginUpdateChecker\v5\PucFactory' ) ) {
 
-			$updater = PucFactory::buildUpdateChecker(
-				static::UPDATE_URL,
-				\SHOP_HEALTH_FILE,
-				'shop-health'
-			);
+			try{ 
+				PucFactory::buildUpdateChecker(
+					static::UPDATE_URL,
+					\SHOP_HEALTH_FILE,
+					'shop-health'
+				);
+
+			}catch( Throwable $error ){
+				// Do nothing. Just no new updates found.
+			}
 		}
 
 		// Send data after plugin update.

--- a/src/WordPress/Updates.php
+++ b/src/WordPress/Updates.php
@@ -29,14 +29,14 @@ class Updates implements Hookable {
 		// Register git updater, if it exists.
 		if ( \class_exists( 'YahnisElsts\PluginUpdateChecker\v5\PucFactory' ) ) {
 
-			try{ 
+			try {
 				PucFactory::buildUpdateChecker(
 					static::UPDATE_URL,
 					\SHOP_HEALTH_FILE,
 					'shop-health'
 				);
 
-			}catch( Throwable $error ){
+			}catch ( Throwable $error ) {
 				// Do nothing. Just no new updates found.
 			}
 		}


### PR DESCRIPTION
- Fixes initial error in #2 .
- Just adds a simple try/catch. tested with staging.wooping.io by removing the version number (temporarily)