### PR TITLE
Removes the plugin from the network plugins page.

### DIFF
--- a/shop-health.php
+++ b/shop-health.php
@@ -32,6 +32,13 @@ require SHOP_HEALTH_PATH . '/vendor/autoload.php';
 
 // Upon activation check if the data model is in order.
 register_activation_hook( SHOP_HEALTH_FILE, function() {
+
+	// @temp: prevent users from enabling this plugin on a network.
+	if( \is_network_admin() ){
+		deactivate_plugins( plugin_basename( SHOP_HEALTH_FILE ) );
+		wp_die( 'This plugin cannot be activated on a multisite network.' );
+	}
+
 	( new Plugin() )->install();
 } );
 

--- a/shop-health.php
+++ b/shop-health.php
@@ -35,7 +35,7 @@ register_activation_hook( SHOP_HEALTH_FILE, function() {
 
 	// @temp: prevent users from enabling this plugin on a network.
 	if( \is_network_admin() ){
-		deactivate_plugins( plugin_basename( SHOP_HEALTH_FILE ) );
+		deactivate_plugins( plugin_basename( SHOP_HEALTH_FILE ), true, true );
 		wp_die( 'This plugin cannot be activated on a multisite network.' );
 	}
 

--- a/src/WordPress/ManagePluginActions.php
+++ b/src/WordPress/ManagePluginActions.php
@@ -17,7 +17,12 @@ class ManagePluginActions implements Hookable {
 	 * Registers the hooks for the menu items in the admin menu.
 	 */
 	public function register_hooks(): void {
+		
+		// Add settings link.
 		\add_action( 'plugin_action_links_' . \plugin_basename( \SHOP_HEALTH_FILE ), [ $this, 'add_settings_link' ], 100 );
+
+		// @temp Remove support for network activation 
+		\add_filter( 'all_plugins', [ $this, 'remove_plugin_in_network_context' ]);
 	}
 
 	/**
@@ -32,5 +37,22 @@ class ManagePluginActions implements Hookable {
 		\array_unshift( $links, $settings_link );
 
 		return $links;
+	}
+
+
+	/**
+	 * Remove Wooping Shop Health on the network plugins page
+	 * @temporary fix until there's full multisite support.
+	 * 
+	 */
+	public function remove_plugin_in_network_context( array $plugins ): array {
+		global $current_screen;
+
+		if( $current_screen->is_network ){
+			unset( $plugins[ 'wooping-shop-health/shop-health.php' ] );
+		}
+		
+		return $plugins;
+
 	}
 }

--- a/src/WordPress/ManagePluginActions.php
+++ b/src/WordPress/ManagePluginActions.php
@@ -21,8 +21,6 @@ class ManagePluginActions implements Hookable {
 		// Add settings link.
 		\add_action( 'plugin_action_links_' . \plugin_basename( \SHOP_HEALTH_FILE ), [ $this, 'add_settings_link' ], 100 );
 
-		// @temp Remove support for network activation 
-		\add_filter( 'all_plugins', [ $this, 'remove_plugin_in_network_context' ]);
 	}
 
 	/**
@@ -39,20 +37,4 @@ class ManagePluginActions implements Hookable {
 		return $links;
 	}
 
-
-	/**
-	 * Remove Wooping Shop Health on the network plugins page
-	 * @temporary fix until there's full multisite support.
-	 * 
-	 */
-	public function remove_plugin_in_network_context( array $plugins ): array {
-		global $current_screen;
-
-		if( $current_screen->is_network ){
-			unset( $plugins[ 'wooping-shop-health/shop-health.php' ] );
-		}
-		
-		return $plugins;
-
-	}
 }


### PR DESCRIPTION
- Fixes #47 temporarily, until #30 has been released.
- Just removes the plugin from the displayed list so you can't press "network activate". 