### PR TITLE
Add support for different database ports

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -119,6 +119,11 @@ class Plugin {
 		// Retrieve the default port
 		$default_port = \ini_get( 'mysqli.default_port' );
 
+		// Overwrite default port when it's set in DB_HOST
+		if ( strpos( DB_HOST, ':' ) !== false ) {
+			list( , $default_port ) = explode( ':', DB_HOST );
+		}
+
 		$capsule->addConnection(
 			[
 				'driver'    => 'mysql',

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -115,10 +115,15 @@ class Plugin {
 	 */
 	public function boot(): void {
 		$capsule = new Capsule();
+
+		// Retrieve the default port
+		$default_port = \ini_get( 'mysqli.default_port' );
+
 		$capsule->addConnection(
 			[
 				'driver'    => 'mysql',
 				'host'      => \DB_HOST,
+				'port'      => $default_port,
 				'database'  => \DB_NAME,
 				'username'  => \DB_USER,
 				'password'  => \DB_PASSWORD,


### PR DESCRIPTION
- Adds the database port (retrieved from `mysqli.default_port`)
- Overwrites the port when a port is set in `DB_HOST`

### Tested on
- Laravel Herd environment on MacOS
- Windows 11 via Parallels Desktop on MacOS