### PR TITLE
Add span as exception node

### DIFF
--- a/assets/src/js/item-list.js
+++ b/assets/src/js/item-list.js
@@ -5,7 +5,8 @@ document.addEventListener( "DOMContentLoaded", () => {
 	const products = document.querySelectorAll( ".wsh-issues-table__product" );
 	[ ...products ].forEach( ( product ) => {
 		product.addEventListener( "click", ( e ) => {
-			if ( e.target.nodeName === "A" || e.target.nodeName === 'BUTTON' ) {
+			console.log( e );
+			if ( e.target.nodeName === "A" || e.target.nodeName === "BUTTON" || e.target.nodeName === "SPAN" ) {
 				return;
 			}
 			slideToggle( product.querySelector( ".wsh-issues-table__issues-container" ), 300, { display: "grid" } );


### PR DESCRIPTION
This PR fixes a bug where clicking on the documentation link in the product issue overview collapsed the issue list.

It doesn't do that anymore now.

# Test instrcutions
1. Check out this branch
2. Make sure you've ran `npx mix`
3. Go to the issue table in the Wooping dashboard
4. Open a list of issues under a product
5. Click on the documentation link
6. See that the issue list no longer collapses.