### PR TITLE
Run settings scan on WooCommerce setting save.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -15,6 +15,7 @@ use Wooping\ShopHealth\Rest\ScanProgress;
 use Wooping\ShopHealth\Rest\ScanShop;
 use Wooping\ShopHealth\Rest\UpdateIssueStatus;
 use Wooping\ShopHealth\WooCommerce\Admin\Products;
+use Wooping\ShopHealth\WooCommerce\Admin\Settings;
 use Wooping\ShopHealth\WooCommerce\Compatibility;
 use Wooping\ShopHealth\WordPress\Assets;
 use Wooping\ShopHealth\WordPress\HandleAdminRequest;
@@ -96,6 +97,7 @@ class Plugin {
 		// WooCommerce hooks.
 		( new Compatibility() )->register_hooks();
 		( new Products() )->register_hooks();
+		( new Settings() )->register_hooks();
 
 		// ShopHealth hooks.
 		( new Updates() )->register_hooks();
@@ -121,7 +123,7 @@ class Plugin {
 
 		// Overwrite default port when it's set in DB_HOST
 		if ( \strpos( \DB_HOST, ':' ) !== false ) {
-			list( , $default_port ) = \explode( ':', \DB_HOST );
+			[ , $default_port ] = \explode( ':', \DB_HOST );
 		}
 
 		$capsule->addConnection(

--- a/src/WooCommerce/Admin/Settings.php
+++ b/src/WooCommerce/Admin/Settings.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Wooping\ShopHealth\WooCommerce\Admin;
+
+use Wooping\ShopHealth\Contracts\Interfaces\Hookable;
+use Wooping\ShopHealth\Controllers\Cron;
+
+/**
+ * Handle all admin settings.
+ */
+class Settings implements Hookable {
+
+	/**
+	 * Registers WordPress action and filter hooks.
+	 *
+	 * @return void
+	 */
+	public function register_hooks(): void {
+		\add_action( 'woocommerce_update_options', [ $this, 'scan_on_setting_save' ], 10 );
+	}
+
+	/**
+	 * Scan all settings when WooCommerce settings are saved.
+	 */
+	public function scan_on_setting_save(): void {
+		( new Cron() )->schedule_all_setting_scans();
+	}
+}


### PR DESCRIPTION
This PR adds functionality that schedules a cron job to scan all settings again after saving the WooCommerce settings.

# Test instructions
1. Check out this branch
2. Go to the WooCommerce settings page
3. Alter any setting
4. Press save
5. See that a new job is schedules to scan the settings.

Fixes #14 