### PR TITLE
Add version number to database.

### DIFF
--- a/src/Models/Database/Options.php
+++ b/src/Models/Database/Options.php
@@ -10,6 +10,11 @@ use Wooping\ShopHealth\Helpers\Statistics;
 class Options {
 
 	/**
+	 * The group name under which the options are stored.
+	 */
+	protected string $group_name = 'wooping_shop_health';
+
+	/**
 	 * Save the statistics for the dashboard page
 	 */
 	public function save_statistics(): array {
@@ -46,5 +51,24 @@ class Options {
 		foreach ( $options as $option ) {
 			\delete_option( $option );
 		}
+	}
+
+	/**
+	 * A temporary method to save a version number.
+	 * We will need this for future update routines.
+	 *
+	 * Should be replaced when a decent Option class and update routine are in place.
+	 *
+	 * @since 1.2
+	 */
+	public function version_number() {
+		$options = get_option( $this->group_name );
+
+		if( ! isset( $options['version'] ) ) {
+			$options['version'] = SHOP_HEALTH_VERSION;
+			update_option( $this->group_name, $options );
+		}
+
+		return $options['version'];
 	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -40,7 +40,7 @@ class Plugin {
 		( new Migrations() )->run();
 
 		// Save a copy of the stats.
-		( new Options() )->save_statistics();
+		$options = ( new Options() )->save_statistics();
 
 		// Schedule a max_scores calculation.
 		if ( \function_exists( 'as_enqueue_async_action' ) ) {
@@ -99,6 +99,8 @@ class Plugin {
 
 		// ShopHealth hooks.
 		( new Updates() )->register_hooks();
+
+		( new Options )->version_number();
 
 		// If we're in WP CLI mode, enable commands.
 		if ( \defined( 'WP_CLI' ) && \WP_CLI ) {


### PR DESCRIPTION
# Scope
In order to know a version number that was running before an update, so that we can use that in future update routines, we need to store that number somewhere in the database. An option seems like the best place for that for now.

This PR adds a check if the version number exists, and if not, sets it to the current one. This will do for now and will in a later stadium be replaced by a better method.