### PR TITLE
Adds multisite support to our migrations

### DIFF
--- a/shop-health.php
+++ b/shop-health.php
@@ -37,13 +37,6 @@ require SHOP_HEALTH_PATH . '/vendor/autoload.php';
 
 // Upon activation check if the data model is in order.
 register_activation_hook( SHOP_HEALTH_FILE, function() {
-
-	// @temp: prevent users from enabling this plugin on a network.
-	if( \is_network_admin() ){
-		deactivate_plugins( plugin_basename( SHOP_HEALTH_FILE ), true, true );
-		wp_die( 'This plugin cannot be activated on a multisite network.' );
-	}
-
 	( new Plugin() )->install();
 } );
 

--- a/src/Contracts/Schema.php
+++ b/src/Contracts/Schema.php
@@ -15,7 +15,7 @@ abstract class Schema {
 	protected function get_table_name(): string {
 		global $wpdb;
 
-		return $wpdb->base_prefix . $this->table_name;
+		return $wpdb->prefix . $this->table_name;
 	}
 
 	/**


### PR DESCRIPTION
- Fixes #30 

But not in the way as stated in the issue itself:
While I don't like the whole "let's double every database table" approach in multisite, it's the default. It's also what some of our users have already done by enabling this plugin on a site-by-site basis in the multisite installation. So this solution basically delivers an array of blog_ids to our migrations and check if we need to do a `switch_to_blog()` if we're in a multisite install. 

It also changes the default prefix in the Scheme class to `$wpdb->prefix` instead of `$wpdb->base_prefix`, simply because the latter is the main prefix.

Additionally, it gets rid of the notice that you can't enable the plugin with `network activate`, because you can now :) 