### PR TITLE
Sets up the new filter system.

### DIFF
--- a/shop-health.php
+++ b/shop-health.php
@@ -64,16 +64,16 @@ function shop_health_plugin(): Plugin {
 
 	$plugin = new Plugin();
 
-	do_action( 'wooping_shop_health_before_boot' );
+	do_action( 'wooping/shop-health/before_boot' );
 	
 	$plugin->boot();
 
-	do_action( 'wooping_shop_health_after_boot' );
+	do_action( 'wooping/shop-health/after_boot' );
 
 	$plugin->init();
 
 	// Allow other plugins to hook into this.
-	do_action( 'wooping_shop_health_loaded' );
+	do_action( 'wooping/shop-health/ready' );
 
 	return $plugin;
 }

--- a/src/WordPress/Assets.php
+++ b/src/WordPress/Assets.php
@@ -43,7 +43,7 @@ class Assets implements Hookable {
 			'shopHealth',
 			[
 				'currencySymbol' => \get_woocommerce_currency_symbol(),
-				'api_url'        => \apply_filters( 'wooping_api_url', 'https://wooping.io/wp-json/wooping/v1' ),
+				'api_url'        => \apply_filters( 'wooping/global/api_url', 'https://wooping.io/wp-json/wooping/v1' ),
 			]
 		);
 		\wp_enqueue_script( 'wooping_shop_health_js' );

--- a/src/routes.php
+++ b/src/routes.php
@@ -62,6 +62,6 @@ if ( ! function_exists( 'wooping_get_routes' ) ) {
 		];
 
 		// add a filter for other plugins and return the routes.
-		return apply_filters( 'wooping_routes', $routes );
+		return apply_filters( 'wooping/global/routes', $routes );
 	}
 }

--- a/templates/components/setting-tabs.php
+++ b/templates/components/setting-tabs.php
@@ -1,5 +1,5 @@
 <?php
-$tabs = apply_filters('wooping_settings_tabs', [
+$tabs = apply_filters( 'wooping/settings/tabs', [
 	'settings' => esc_html__( 'Ignored issues', 'wooping-shop-health' ),
 ]);
 ?>


### PR DESCRIPTION
Fixes #17

Changes the few filters that where already in place, per @mklasen's suggestions:
`wooping_shop_health_loaded` -> `wooping/shop-health/ready`
`wooping_routes` -> `wooping/global/routes`
`wooping_api_url` -> `wooping/global/api_url`
`woop_assets_pages` -> `wooping/assets/pages`
`wooping_settings_tabs` -> `wooping/settings/tabs`

Also adds the following filters to validators:

- `wooping/validators/$slug/severity`
- `wooping/validators/$slug/requirements`
- `wooping/validators/$slug/can_be_resolved`

$slug in this example is a snake-cased version of the validator name, for instance `has_category`