### PR TITLE
Update routines

### DIFF
--- a/src/Contracts/ProductValidator.php
+++ b/src/Contracts/ProductValidator.php
@@ -3,6 +3,7 @@
 namespace Wooping\ShopHealth\Contracts;
 
 use WC_Product;
+use Wooping\ShopHealth\Models\Database\Options;
 use Wooping\ShopHealth\Models\ScannedObject;
 
 /**
@@ -27,9 +28,8 @@ abstract class ProductValidator extends Validator {
 	 * Does this validator have the requirements to run at all?
 	 */
 	public function can_run(): bool {
-
 		// Check if this validator is on the "mass-ignore" list.
-		$ignored_validators = \get_option( 'wooping_shop_health_ignored_validators', [] );
+		$ignored_validators = Options::get( 'ignored_validators', [] );
 
 		// Don't run it if it is.
 		if ( \in_array( $this->get_validator_short_name(), $ignored_validators, true ) ) {

--- a/src/Controllers/Dashboard/Dashboard.php
+++ b/src/Controllers/Dashboard/Dashboard.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
 use Wooping\ShopHealth\Contracts\Controller;
 use Wooping\ShopHealth\Helpers\Scans;
 use Wooping\ShopHealth\Helpers\ScoreCalculator;
+use Wooping\ShopHealth\Models\Database\Options;
 use Wooping\ShopHealth\Models\Issue;
 
 /**
@@ -72,7 +73,7 @@ class Dashboard extends Controller {
 			'shop_issues'             => $shop_issues,
 			'product_issues'          => $all_product_issues,
 			'pressing_product_issues' => $pressing_product_issues,
-			'stats'                   => \get_option( 'wooping_shop_health_statistics' ),
+			'stats'                   => Options::get( 'health_statistics' ),
 			'has_hpos'                => $has_hpos,
 			'last_scan'               => $last_scan,
 			'scans_in_progress'       => Scans::get_total_pending_jobs_in_queue(),

--- a/src/Controllers/Settings.php
+++ b/src/Controllers/Settings.php
@@ -3,6 +3,7 @@
 namespace Wooping\ShopHealth\Controllers;
 
 use Wooping\ShopHealth\Contracts\Controller;
+use Wooping\ShopHealth\Models\Database\Options;
 
 /**
  * Class IssuesController
@@ -40,7 +41,7 @@ class Settings extends Controller {
 		if ( isset( $_POST['ignored_validators'] ) && \is_array( $_POST['ignored_validators'] ) ) { // phpcs:ignore
 
 			// get the old ignored validators.
-			$old_ignored_validators = \get_option( 'wooping_shop_health_ignored_validators', [] );
+			$old_ignored_validators = Options::get( 'ignored_validators' ) ?? [];
 
 			// sanitize value. ignored_validators are sanitized, but as text.
 			$validators = [];
@@ -49,7 +50,7 @@ class Settings extends Controller {
 			}
 
 			// update the option.
-			\update_option( 'wooping_shop_health_ignored_validators', $validators );
+			Options::set( 'ignored_validators', $validators );
 
 			// and trigger a bulk-ignore check.
 			\as_enqueue_async_action(
@@ -64,7 +65,7 @@ class Settings extends Controller {
 
 		}else {
 			// update the option with an empty array as default.
-			\update_option( 'wooping_shop_health_ignored_validators', [] );
+			Options::set( 'ignored_validators', [] );
 		}
 
 		// return back to the settings page.

--- a/src/Models/Database/Options.php
+++ b/src/Models/Database/Options.php
@@ -12,7 +12,7 @@ class Options {
 	/**
 	 * The group name under which the options are stored.
 	 */
-	protected string $group_name = 'wooping_shop_health';
+	protected static string $group_name = 'wooping_shop_health';
 
 	/**
 	 * Save the statistics for the dashboard page
@@ -20,7 +20,7 @@ class Options {
 	public function save_statistics(): array {
 
 		$stats = ( new Statistics() )->get();
-		\update_option( 'wooping_shop_health_statistics', $stats );
+		self::set( 'health_statistics', $stats );
 
 		return $stats;
 	}
@@ -62,13 +62,27 @@ class Options {
 	 * @since 1.2
 	 */
 	public function version_number() {
-		$options = get_option( $this->group_name );
+		$options = \get_option( self::$group_name );
 
 		if( ! isset( $options['version'] ) ) {
 			$options['version'] = SHOP_HEALTH_VERSION;
-			update_option( $this->group_name, $options );
+			\update_option( self::$group_name, $options );
 		}
 
 		return $options['version'];
+	}
+
+	public static function get( $key ) {
+		$options = get_option( self::$group_name );
+
+		return $options[ $key ] ?? false;
+	}
+
+	public static function set( $key, $value ) {
+		$options = get_option( self::$group_name );
+
+		$options[ $key ] = $value;
+
+		\update_option( self::$group_name, $options );
 	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -80,6 +80,11 @@ class Plugin {
 	 */
 	public function init(): void {
 
+		// Check if updates should be run
+		if ( version_compare( Options::get( 'version' ), SHOP_HEALTH_VERSION, '<' ) ) {
+			( new \Wooping\ShopHealth\Updates\Updates() )->run_updates();
+		}
+
 		// General WordPress hooks.
 		( new Assets() )->register_hooks();
 		( new RegisterPages() )->register_hooks();

--- a/src/Updates/Updates.php
+++ b/src/Updates/Updates.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Handle update routines for the plugin.
+ */
+
+namespace Wooping\ShopHealth\Updates;
+
+use Wooping\ShopHealth\Models\Database\Options;
+
+class Updates {
+	protected Options $options;
+
+	/**
+	 * An array of version numbers with their corresponding update routines.
+	 * Each routine represents a method.
+	 */
+	protected array $update_routines = [
+		'1.3.0' => '130',
+	];
+
+	/**
+	 * Run defined update routines.
+	 */
+	public function run_updates(): void {
+		foreach ( $this->update_routines as $version ) {
+			// Check if a update routine has a higher version number than the one currently stored in the database.
+			// If so: we need to run this routine.
+			if ( version_compare( Options::get( 'version' ), $version, '<' ) ) {
+				call_user_func( [ $this, 'update_' . $version ] );
+			}
+		}
+
+		// After all update routines are done, update the version in the database
+		Options::set( 'version', SHOP_HEALTH_VERSION );
+
+
+		// Provide the ability to hook into
+		do_action( 'wooping/shop-health/after_update_routines', Options::get( 'version' ) );
+	}
+
+	protected function update_130() {
+		$old_options = [
+			'wooping_shop_health_ignored_validators',
+			'wooping_shop_health_scan_last_triggered',
+			'wooping_shop_health_statistics',
+			'wooping_shop_health_max_scores',
+		];
+
+		foreach( $old_options as $old_option ) {
+			$new_option_name = str_replace( 'wooping_shop_health_', '', $old_option );
+			Options::set( $new_option_name, get_option( $old_option, '' ) );
+		}
+	}
+}

--- a/src/Updates/Updates.php
+++ b/src/Updates/Updates.php
@@ -22,11 +22,11 @@ class Updates {
 	 * Run defined update routines.
 	 */
 	public function run_updates(): void {
-		foreach ( $this->update_routines as $version ) {
+		foreach ( $this->update_routines as $version => $callback) {
 			// Check if a update routine has a higher version number than the one currently stored in the database.
 			// If so: we need to run this routine.
 			if ( version_compare( Options::get( 'version' ), $version, '<' ) ) {
-				call_user_func( [ $this, 'update_' . $version ] );
+				call_user_func( [ $this, 'update_' . $callback ] );
 			}
 		}
 


### PR DESCRIPTION
This PR adds functionality to add update routines. It compares the version stored in the database with the new one from the plugin main file and runs the necessary update routines when required.

Fixes #66 