### PR TITLE
removes is_plugin_active for now as it's causing a fatal.

### DIFF
--- a/shop-health.php
+++ b/shop-health.php
@@ -32,10 +32,6 @@ if ( ! file_exists( SHOP_HEALTH_PATH . '/vendor/autoload.php' ) ) {
 	return;
 }
 
-if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
-	return;
-}
-
 require SHOP_HEALTH_PATH . '/vendor/autoload.php';
 
 // Upon activation check if the data model is in order.


### PR DESCRIPTION
`is_plugin_active` is only available after `admin_init`, which runs later then the bootstrap for our plugin.

Trying to shoehorn this in today doesn't seem like a good idea, because we simply don't have time to test every nook and cranny of the plugin to see if it still works if we delay the bootstrapping sequence.