### PR TITLE
Hotfix/fatal on product save

### DIFF
--- a/src/Contracts/ProductValidator.php
+++ b/src/Contracts/ProductValidator.php
@@ -29,10 +29,13 @@ abstract class ProductValidator extends Validator {
 	 */
 	public function can_run(): bool {
 		// Check if this validator is on the "mass-ignore" list.
-		$ignored_validators = Options::get( 'ignored_validators', [] );
-
+		$ignored_validators = Options::get( 'ignored_validators' );
+		
 		// Don't run it if it is.
-		if ( \in_array( $this->get_validator_short_name(), $ignored_validators, true ) ) {
+		if ( 
+			\is_array( $ignored_validators ) && 
+			\in_array( $this->get_validator_short_name(), $ignored_validators, true ) 
+		) {
 			return false;
 		}
 


### PR DESCRIPTION
if ignored_validators has never been saved in your database, it's a string, not an array. 
Hurray for serialized arrays. 

This fixes a potential fatal error when saving products.